### PR TITLE
Added view for Redeem Token

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,6 +18,8 @@ import CampaignsList from "./features/campaigns/CampaignsList";
 import CampaignsGrid from "./features/campaigns/CampaignsGrid";
 import Campaign from "./features/campaigns/Campaign";
 import HomePage from "./components/HomePage";
+import RedeemOverview from "./features/campaigns/RedeemOverview";
+import RedeemPage from "./features/campaigns/RedeemPage";
 
 function App() {
 	return (
@@ -47,6 +49,12 @@ function App() {
                     <Route path="logout" element={<Logout />}/>
                     <Route path="register" element={<Register />}/>
                     <Route path="home" element={<HomePage />}/>
+
+                    <Route path="redeem">
+                        <Route index element={<RedeemOverview />}/>
+                        <Route path=":token" element={<RedeemPage />} />
+                    </Route>
+
                     {/* Protected Routes */}
 					<Route element={<PersistLogin />}>
 

--- a/client/src/components/MainHeader.js
+++ b/client/src/components/MainHeader.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Layout, Typography, Menu, Button } from "antd";
-import { AuditOutlined, BarChartOutlined, EuroOutlined, HomeOutlined, LoginOutlined, LogoutOutlined, UserOutlined } from "@ant-design/icons";
+import { AuditOutlined, BarChartOutlined, EuroOutlined, HomeOutlined, LoginOutlined, LogoutOutlined, QrcodeOutlined, UserOutlined } from "@ant-design/icons";
 import logo from "../logo.svg";
 import { Link, useLocation } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
@@ -18,6 +18,11 @@ const defaultMenu = [
 		label: (<Link to='/campaigns'>Campaigns</Link>),
 		key: "/campaigns",
 		icon: <EuroOutlined />,
+	},
+    {
+		label: (<Link to='/redeem'>Redeem</Link>),
+		key: "/redeem",
+		icon: <QrcodeOutlined />,
 	},
 ];
 
@@ -124,7 +129,8 @@ const MainHeader = () => {
         location.pathname === "/" || location.pathname === ""
             ? "/home"
             //When reaching '/campaigns/campaingId' I overwrite the current to highlights Campaigns
-            : (location.pathname.includes("/campaigns/") ? '/campaigns' : location.pathname),
+            : (location.pathname.includes("/campaigns/") ? '/campaigns'
+            : (location.pathname.includes("/redeem/") ? '/redeem' : location.pathname)),
     );
     const [disableOverflow, setDisableOverflow] = useState(false);
 
@@ -136,6 +142,8 @@ const MainHeader = () => {
                 let newCurrent = location.pathname
                 // When reaching '/campaigns/campaingId' I overwrite the current to highlights Campaigns
                 if (location.pathname.includes("/campaigns/")) newCurrent = '/campaigns'
+                // same for the redeem
+                else if (location.pathname.includes("/redeem/")) newCurrent = '/redeem'
                 setCurrent(newCurrent);
             }
         }

--- a/client/src/features/campaigns/RedeemOverview.js
+++ b/client/src/features/campaigns/RedeemOverview.js
@@ -1,0 +1,55 @@
+import { QrcodeOutlined } from "@ant-design/icons";
+import { Button, Col, Flex, Image, Input, Row, Space, theme, Typography } from "antd";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+
+const { Title } = Typography;
+const RedeemOverview = () => {
+    const [code, setCode] = useState("")
+
+    const { token: styleToken } = theme.useToken();
+	const styleContainer = {
+		color: styleToken.colorTextTertiary,
+		backgroundColor: styleToken.colorBgLayout,//"#eeebe4",
+		borderRadius: styleToken.borderRadiusLG,
+		border: `1px solid ${styleToken.colorBorder}`,
+        width: "80%",
+        paddingBottom: 32,
+	};
+
+
+	return (
+		<div style={{ backgroundColor:"#bfbab4", padding: 20}}>
+			<Row>
+				<Col span={12}>
+					<Flex justify="center" align="center" style={{ height: "100%", paddingTop: 30}}>
+                        <Space direction="vertical"size={25} align="center" style={styleContainer}>
+                            <Title level={2}>Do you have a code?</Title>
+                            <Input
+                                placeholder="Paste the code"
+                                size="large"
+                                prefix={<QrcodeOutlined />}
+                                style={{ minWidth: 300}}
+                                onChange={(e) => {setCode(e.target.value)}}
+                            />
+                            <Link to={`/redeem/${code}`}>
+                                <Button type="primary" shape="round" size="large">
+                                    Redeem Now
+                                </Button>
+                            </Link>
+                        </Space>
+					</Flex>
+				</Col>
+				<Col span={12}>
+                <Image
+                    
+                    preview={false}
+                    src="/img/FoundRaisingAi.jpg"
+                />
+				</Col>
+			</Row>
+		</div>
+	);
+};
+
+export default RedeemOverview;

--- a/client/src/features/campaigns/RedeemPage.js
+++ b/client/src/features/campaigns/RedeemPage.js
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useRedeemTokenMutation } from "../../context/contextApiSlice";
+import { Button, Col, Flex, Image, Result, Row, Space, Spin, theme } from "antd";
+import jwtDecode from "jwt-decode";
+import { LoadingOutlined } from "@ant-design/icons";
+
+const RedeemPage = () => {
+	const [invalidToken, setInvalidToken] = useState(false);
+	const [test, setTest] = useState(undefined);
+	const [campaignId, setCampaignId] = useState(undefined);
+
+	// id campaign
+	const { token } = useParams();
+	const [redeemToken, { isLoading, isFetching, isSuccess, isError, error }] =
+		useRedeemTokenMutation();
+
+	const { token: styleToken } = theme.useToken();
+	const styleContainer = {
+		color: styleToken.colorTextTertiary,
+		backgroundColor: styleToken.colorBgLayout,//"#eeebe4",
+		borderRadius: styleToken.borderRadiusLG,
+		border: `1px solid ${styleToken.colorBorder}`,
+		marginTop: 16,
+        width: "80%",
+	};
+
+	useEffect(() => {
+		// Only trigger mutation once, even if useEffect fires more times: if there is a result or the token is not a jwt (or expired) no mutation are fired
+		if (
+			token &&
+			!isLoading &&
+			!isSuccess &&
+			!isError &&
+			!isFetching &&
+			!invalidToken
+		) {
+			// verify the token is a valid JWT
+			try {
+				const decoded = jwtDecode(token);
+
+                // If is not a jwt or is expired (we need to have the date selected)
+				if (!decoded) {	// || !decoded.exp || Date.now() > (decoded.exp * 1000)) {
+					setInvalidToken(true);
+				} else {
+					const { campaignId, campaignAddress, tokenId } = decoded;
+                    console.log({
+                    	campaignId,
+                    	campaignAddress,
+                    	tokenId,
+                    })
+                    redeemToken({
+                    	campaignId,
+                    	campaignAddress,
+                    	tokenId,
+                    });
+					setCampaignId(campaignId);
+				}
+			} catch (e) {
+				setInvalidToken(true);
+			}
+		}
+	}, [token, isLoading, isSuccess, isError, isFetching, invalidToken]);
+
+	const invalidTokenResult = (
+		<Result
+			status="warning"
+			title="The code is invalid or expired."
+			extra={[
+				<Link to="/home">
+					<Button type="primary">Go to Home</Button>
+				</Link>,
+				<Link to="/redeem">
+					<Button>Try Again</Button>
+				</Link>,
+			]}
+		/>
+	);
+
+	const errorTokenResult = (
+		<Result
+			status="error"
+			title="Code not redeemed."
+			subTitle={`There was an error redeeming the code${
+				error ? `: ${error.data.message}.` : `.`
+			}`}
+			extra={[
+				<Link to="/home">
+					<Button type="primary">Go to Home</Button>
+				</Link>,
+				<Link to="/redeem">
+					<Button>Try Again</Button>
+				</Link>,
+			]}
+		/>
+	);
+
+	const successTokenResult = (
+		<Result
+			status="success"
+			title="Successfully Redeemed the Code!"
+			subTitle="Thank you for your Support, we appreciate your Generosity. Check the progress of the campaign below."
+			extra={[
+				<Link to="/home">
+					<Button type="primary">Go to Home</Button>
+				</Link>,
+				<Link to={`/campaigns/${campaignId}`}>
+					<Button>Check the Progress</Button>
+				</Link>,
+			]}
+		/>
+	);
+
+	let content = (
+		<Result
+			icon={<Spin indicator={<LoadingOutlined spin />} size="large" />}
+			title="Loading..."
+		/>
+	);
+	if (invalidToken) content = invalidTokenResult;
+	else if (isError) content = errorTokenResult;
+	else if (isSuccess) content = successTokenResult;
+
+	return (
+		// <div style={{ padding: 50, width: "100%", backgroundColor:"#bfbab4", minHeight:521 }}>
+		// 	<Space
+		// 		direction="vertical"
+		// 		align="center"
+		// 		style={{ width: "100%", backgroundColor:"#bfbab4" }}
+		// 	>
+		// 		<div style={styleContainer}>{content}</div>
+		// 	</Space>
+		// </div>
+        <div style={{ backgroundColor:"#bfbab4", padding: 20}}>
+			<Row>
+				<Col span={12}>
+					<Flex justify="center" align="center" style={{ height: "100%", paddingTop: 30}}>
+                        <div style={styleContainer}>{content}</div>
+					</Flex>
+				</Col>
+				<Col span={12}>
+                <Image
+                    
+                    preview={false}
+                    src="/img/FoundRaisingAi.jpg"
+                />
+				</Col>
+			</Row>
+		</div>
+	);
+};
+
+export default RedeemPage;

--- a/server/controllers/tokensController.js
+++ b/server/controllers/tokensController.js
@@ -39,16 +39,12 @@ const redeemToken = asyncHandler(async (req, res) => {
         token = await checkTokenHash(campaignId, tokenId, campaignAddress);
     } catch (error) {
         // console.log('Error redeeming token:', error);
-        res.json({ message: "Error redeeming token: " + error.message });
-        res.status(400);
-        return;
+        return res.status(400).json({ message: "Error redeeming token: " + error.message });
     }
 
     const isTokenValid = await WEB3_CONTRACT.methods.isTokenValid(campaignAddress, tokenId).call({ from: WEB3_MANAGER_ACCOUNT.address });
     if (!isTokenValid) {
-        res.json({ message: "Token not valid" });
-        res.status(400);
-        return;
+        return res.status(400).json({ message: "Token not valid" });
     }
 
     
@@ -66,8 +62,7 @@ const redeemToken = asyncHandler(async (req, res) => {
     } catch (error) {
         console.log('Error redeeming token:', error);
         errorMessage = retrieveBlockchainError(error);
-        res.json({ message: "Error redeeming token: " + errorMessage });
-        res.status(400);
+        return res.status(400).json({ message: "Error redeeming token: " + errorMessage });
     }
 });
 


### PR DESCRIPTION
I am assuming we are using JWT token to encode all necessary information to the QR CODE, QrCode = localhost:3000/redeem/JWT-token. Added two pages:
 - RedeemPage: decode the jwt token to get the id of campaing, redeemable token and address. Send the request to the server and waits to show the results of the operation
 - RedeemOverview: page to insert the jwt token and once pressed redeem it will redirect to the RedeemPage passing the jwt. This will be useful for testing avoiding to have to pass through the QR code creation and scannign.

Changes on the server:
 - Fixed the returns in case of error. Using only json.status without immediately returing will cause to be "ignored" due to asynchronicity.